### PR TITLE
Use external modules on narwhal and include tuning and testing steps

### DIFF
--- a/.spack/packages-narwhal.yaml
+++ b/.spack/packages-narwhal.yaml
@@ -6,3 +6,8 @@ packages:
       - cray-mpich-ucx/8.1.5
   globalarrays:
     variants: [armci=openib, scalapack=True]
+  cray-libsci:
+    externals:
+    - spec: "cray-libsci"
+      modules:
+      - cray-libsci

--- a/.spack/packages-narwhal.yaml
+++ b/.spack/packages-narwhal.yaml
@@ -3,6 +3,6 @@ packages:
     externals:
     - spec: "mpich@8.1.5%gcc@10.3.0 arch=cray-sles15-zen2"
       modules:
-      - cray-mpich
+      - cray-mpich-ucx/8.1.5
   globalarrays:
     variants: [armci=openib, scalapack=True]

--- a/.spack/packages-narwhal.yaml
+++ b/.spack/packages-narwhal.yaml
@@ -1,13 +1,16 @@
 packages:
+  python:
+    externals:
+    - spec: "python"
+      modules:
+      - cray-python
   mpich:
     externals:
     - spec: "mpich@8.1.5%gcc@10.3.0 arch=cray-sles15-zen2"
       modules:
-      - cray-mpich-ucx/8.1.5
+      - cray-mpich/8.1.5
   globalarrays:
     variants: [armci=openib, scalapack=True]
-  cray-libsci:
-    externals:
-    - spec: "cray-libsci"
-      modules:
-      - cray-libsci
+  all:
+    providers:
+      mpi: [mpich]

--- a/.spack/packages-narwhal.yaml
+++ b/.spack/packages-narwhal.yaml
@@ -9,6 +9,11 @@ packages:
     - spec: "mpich@8.1.5%gcc@10.3.0 arch=cray-sles15-zen2"
       modules:
       - cray-mpich/8.1.5
+  cray-libsci:
+    externals:
+    - spec: "cray-libsci"
+      modules:
+      - cray-libsci 
   globalarrays:
     variants: [armci=openib, scalapack=True]
   all:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ likely take 20 minutes or more.
 $ spack load /hmzfood
 $ spack cd --stage-dir molpro
 $ cd spack-src
-$ make MOLPRO_OPTIONS='-M2g' tuning
+$ make tuning
 ```
 
 Once the tuning process is complete, you will have a file named `tuning.rc` in the `spack-src/lib` folder. 
@@ -62,12 +62,12 @@ spack find --paths molpro
 Finally, you can/should run the tests provided with Molpro:
 
 ```shell
-$ make MOLPRO_OPTIONS='-n2 -M2g' test
+$ make MOLPRO_OPTIONS='-n2' test
 ```
 
 ### Molpro-Narwhal Lessons Learned
 
-So far, Molpro only runs on one node. This is probably an issue with mpich and global arrays.
+TODO: So far, Molpro only runs on one node. This is probably an issue with mpich and global arrays.
 Possible remedy is to run tests in globalarrays to debug. Tried globalarrays variants 
 `armci=[mpi-ts, mpi-pr]` with no luck.
 
@@ -83,8 +83,17 @@ Tried making the spack package as a CMakePackage, but couldn't figure out how to
 to build. The resulting executable seemed to run fine on one node, and the package file is
 `package_CMake_package.py`.
 
-When using cray-libsci, getting core dumps at the end of jobs. Doesn't seem to happen when using
-openblas, netlib-lapack, and netlib-scalapack.
+TODO: Latest build using cray-libsci + cray-mpich (from modules) has core dump at the end of successful job. 
+Doesn't seem to happen when using mpich + openblas + netlib-lapack + netlib-scalapack, but mpich and libsci 
+from modules seems more efficient.  Should try getting a stack trace to see what is happening at job termination.
 
-Not sure what the `-M` option should be...seems to work for `-M2g` but not `-M20g` (that should
-work since 20 x 8 = 160GB). Also, must set `ARMCI_DEFAULT_SHMMAX=8192` (handled in `spack load molpro`).
+See [the Molpro manual](https://www.molpro.net/manual/doku.php?id=general_program_structure#memory_allocation) 
+for info on allocating memory on a given machine. For narwhal standard nodes with 256GB RAM, perhaps these values work:
+
+- `-n 40 -m 375m -G 5000m` (40 CPUs on one node)
+- `-n 30 -m 575m -G 5750m`
+- `-n 20 -m 975m -G 6500m`
+- `-n 2 -m 11775m -G 7850m`
+
+Setting `ARMCI_DEFAULT_SHMMAX` in `spack load molpro` but not sure it matters.
+

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ likely take 20 minutes or more.
 ```shell
 $ spack cd --stage-dir molpro
 $ cd spack-src
-$ make MOLPRO_OPTIONS='-n1 -m28g' tuning
+$ make tuning
 ```
 
 Once the tuning process is complete, you will have a file named `tuning.rc` in the `spack-src/lib` folder. 
-You can either copy the file to `${MOLPRO_PREFIX}/lib/tuning.rc` or copy the contents to 
+You can either copy the file to `${MOLPRO_PREFIX}/molpro_2021.1/lib/tuning.rc` or copy the contents to 
 `${HOME}/.molprorc`. The former is probably the best approach since the tuning is specific to
 a given build of Molpro. To determine `${MOLPRO_PREFIX}` for the given build, run the following command
 and match the hash from the stage/build folder with the hash from the command's output:
@@ -74,8 +74,13 @@ Tried adding `make tuning` and `make test` steps to spack package, but molpro sc
 for nodefile and expects to be run on compute nodes.
 
 Tried running tuning on multiple MPI processes (`make MOLPRO_OPTIONS='-n128 -m28g' tuning`),
-but it seems it is meant for only one process.
+but it seems it is meant for only one process. Or, maybe the number of processes is handled
+automatically and should just do `make tuning` like the instrucions say (not
+`make MOLPRO_OPTIONS='-n1 -m28g' tuning`).
 
 Tried making the spack package as a CMakePackage, but couldn't figure out how to get the tests
 to build. The resulting executable seemed to run fine on one node, and the package file is
 `package_CMake_package.py`.
+
+When using cray-libsci, getting core dumps at the end of jobs. Doesn't seem to happen when using
+openblas, netlib-lapack, and netlib-scalapack.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Go to the staging directory and perform the tuning process which will
 likely take 20 minutes or more.
 
 ```shell
+$ spack load /hmzfood
 $ spack cd --stage-dir molpro
 $ cd spack-src
-$ make tuning
+$ make MOLPRO_OPTIONS='-M2g' tuning
 ```
 
 Once the tuning process is complete, you will have a file named `tuning.rc` in the `spack-src/lib` folder. 
@@ -61,7 +62,7 @@ spack find --paths molpro
 Finally, you can/should run the tests provided with Molpro:
 
 ```shell
-$ make MOLPRO_OPTIONS='-n2 -m28g' test
+$ make MOLPRO_OPTIONS='-n2 -M2g' test
 ```
 
 ### Molpro-Narwhal Lessons Learned
@@ -84,3 +85,6 @@ to build. The resulting executable seemed to run fine on one node, and the packa
 
 When using cray-libsci, getting core dumps at the end of jobs. Doesn't seem to happen when using
 openblas, netlib-lapack, and netlib-scalapack.
+
+Not sure what the `-M` option should be...seems to work for `-M2g` but not `-M20g` (that should
+work since 20 x 8 = 160GB). Also, must set `ARMCI_DEFAULT_SHMMAX=8192` (handled in `spack load molpro`).

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This is the NRL Plasma Physics Division spack package repo.
 ## Installation
 
 Clone this repo somewhere (like $HOME/opt). Copy the `.spack/repos.yaml` 
-file to `$HOME/.spack/repos.yaml`,
-and update it to point to `spack-ppd`:
+file to `$HOME/.spack/repos.yaml`, and update it to point to `spack-ppd`:
 
 ```yaml
 repos:
@@ -19,22 +18,12 @@ Molpro is a commercial code, so you will need to obtain the tarball and update
 the Molpro package in `spack-ppd` to point to it. Do `spack edit molpro` and
 update the `url` line to point to the file.
 
-We want to use the `cray-mpich` module and build a particular variant of
+We want to use a specific mpich module on the system and build a particular variant of
 Global Arrays (`armci=openib` and `scalapack=True`), 
 which is all taken care of in the `.spack/packages.yaml` file. 
-The lines you need to add to `.spack/packages.yaml` are in `.spack/packages-narwhal.yaml`.
+The lines you need to add to `.spack/packages.yaml` are in `.spack/packages-narwhal.yaml`
+in this repo.
 Be sure not to change any of the other contents of the file, and only copy in the `mpich`
-and `globalarrays` blocks--you only want one top-level `packages:` entry).
+and `globalarrays` blocks (you only want one top-level `packages:` entry).
 
-```yaml
-packages:
-  mpich:
-    externals:
-    - spec: "mpich@8.1.5%gcc@10.3.0 arch=cray-sles15-zen2"
-      modules:
-      - cray-mpich
-  globalarrays:
-    variants: [armci=openib, scalapack=True]
-```
-	
 Build and install Molpro with the command `spack install molpro %gcc@10.3.0 ^mpich@8.1.5`.

--- a/README.md
+++ b/README.md
@@ -39,13 +39,40 @@ perform some tests, requiring access to a compute node, so start an interactive 
 $ qsub -l ccm=1 -l select=1:ncpus=128:mpiprocs=128 -A NRLDC31794610 -q standard -l walltime=02:00:00 -I
 ```
 
-Go to the staging directory and perform the tuning an testing processes. The tuning step
-will likely take 10-20 minutes. Then re-install:
+Go to the staging directory and perform the tuning process which will
+likely take 20  minutes or more.
 
 ```shell
 $ spack cd --stage-dir molpro
 $ cd spack-build-[hash]
-$ make MOLPRO_OPTIONS='-n128 -m28g' tuning
-$ make MOLPRO_OPTIONS='-n128 -m28g' test
-$ make install
+$ make MOLPRO_OPTIONS='-n1 -m28g' tuning
 ```
+
+Once the tuning process is complete, you will have a file named `tuning.rc` in the `lib` folder. 
+You can either copy the file to `${MOLPRO_PREFIX}/lib/tuning.rc` or copy the contents to 
+`${HOME}/.molprorc`. The former is probably the best approach since the tuning is specific to
+a given build of Molpro. To determine `${MOLPRO_PREFIX}` for the given build, run the following command
+and match the hash from the stage/build folder with the hash from the command's output:
+
+```shell
+spack find --paths molpro
+```
+
+Finally, you can/should run the tests provided with Molpro:
+
+```shell
+$ make MOLPRO_OPTIONS='-n2 -m28g' test
+```
+
+### Molpro-Narwhal Lessons Learned
+
+So far, Molpro only runs on one node. This is probably an issue with mpich and global arrays.
+Possible remedy is to run tests in globalarrays to debug. Tried globalarrays variants 
+`armci=[mpi-ts, mpi-pr]` with no luck.
+
+Tried adding `make tuning` and `make test` steps to spack package, but molpro script looks
+for nodefile and expects to be run on compute nodes.
+
+Tried running tuning on multiple MPI processes (`make MOLPRO_OPTIONS='-n128 -m28g' tuning`),
+but it seems it is meant for only one process.
+

--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ $ qsub -l ccm=1 -l select=1:ncpus=128:mpiprocs=128 -A NRLDC31794610 -q standard 
 ```
 
 Go to the staging directory and perform the tuning process which will
-likely take 20  minutes or more.
+likely take 20 minutes or more.
 
 ```shell
 $ spack cd --stage-dir molpro
-$ cd spack-build-[hash]
+$ cd spack-src
 $ make MOLPRO_OPTIONS='-n1 -m28g' tuning
 ```
 
-Once the tuning process is complete, you will have a file named `tuning.rc` in the `lib` folder. 
+Once the tuning process is complete, you will have a file named `tuning.rc` in the `spack-src/lib` folder. 
 You can either copy the file to `${MOLPRO_PREFIX}/lib/tuning.rc` or copy the contents to 
 `${HOME}/.molprorc`. The former is probably the best approach since the tuning is specific to
 a given build of Molpro. To determine `${MOLPRO_PREFIX}` for the given build, run the following command
@@ -76,3 +76,6 @@ for nodefile and expects to be run on compute nodes.
 Tried running tuning on multiple MPI processes (`make MOLPRO_OPTIONS='-n128 -m28g' tuning`),
 but it seems it is meant for only one process.
 
+Tried making the spack package as a CMakePackage, but couldn't figure out how to get the tests
+to build. The resulting executable seemed to run fine on one node, and the package file is
+`package_CMake_package.py`.

--- a/README.md
+++ b/README.md
@@ -26,4 +26,26 @@ in this repo.
 Be sure not to change any of the other contents of the file, and only copy in the `mpich`
 and `globalarrays` blocks (you only want one top-level `packages:` entry).
 
-Build and install Molpro with the command `spack install molpro %gcc@10.3.0 ^mpich@8.1.5`.
+Install Molpro and keep the stage directory for tuning and testing:
+
+```shell
+$ spack install --keep-stage molpro %gcc@10.3.0 ^mpich@8.1.5
+```
+
+The package tuning and testing process will run molpro to establish some tuning parameters and 
+perform some tests, requiring access to a compute node, so start an interactive job:
+
+```shell
+$ qsub -l ccm=1 -l select=1:ncpus=128:mpiprocs=128 -A NRLDC31794610 -q standard -l walltime=02:00:00 -I
+```
+
+Go to the staging directory and perform the tuning an testing processes. The tuning step
+will likely take 10-20 minutes. Then re-install:
+
+```shell
+$ spack cd --stage-dir molpro
+$ cd spack-build-[hash]
+$ make MOLPRO_OPTIONS='-n128 -m28g' tuning
+$ make MOLPRO_OPTIONS='-n128 -m28g' test
+$ make install
+```

--- a/packages/molpro/package.py
+++ b/packages/molpro/package.py
@@ -21,8 +21,7 @@ class Molpro(AutotoolsPackage):
     depends_on('icu4c')
     depends_on('eigen')
     depends_on('mpi')
-    depends_on('blas')
-    depends_on('netlib-lapack')
+    depends_on('cray-libsci')
     depends_on('globalarrays')
     depends_on('libxml2')
 
@@ -39,4 +38,4 @@ class Molpro(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path('PATH', '{0}/molpro_2021.1/bin'.format(self.prefix))
-        env.set('ARMCI_DEFAULT_SHMMAX', '8192')
+        env.set('ARMCI_DEFAULT_SHMMAX', '128')

--- a/packages/molpro/package.py
+++ b/packages/molpro/package.py
@@ -39,3 +39,4 @@ class Molpro(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path('PATH', '{0}/molpro_2021.1/bin'.format(self.prefix))
+        env.set('ARMCI_DEFAULT_SHMMAX', '8192')

--- a/packages/molpro/package.py
+++ b/packages/molpro/package.py
@@ -21,14 +21,19 @@ class Molpro(AutotoolsPackage):
     depends_on('icu4c')
     depends_on('eigen')
     depends_on('mpi')
-    depends_on('cray-libsci')
+    depends_on('blas')
+    depends_on('netlib-lapack')
     depends_on('globalarrays')
     depends_on('libxml2')
 
-    def configure_args(self):
-        args = []
-
-        args.append('--cache-file=test-cache.txt')
-
-        return args
+    #def configure_args(self):
+#
+        ## Make sure we use Spack's blas/lapack:
+        #lapack_libs = spec['blas'].libs.joined(';')
+#
+        #args = [
+            #self.define('--with-lapack-path', lapack_libs),
+            #]
+#
+        #return args
 

--- a/packages/molpro/package.py
+++ b/packages/molpro/package.py
@@ -37,3 +37,5 @@ class Molpro(AutotoolsPackage):
 #
         #return args
 
+    def setup_run_environment(self, env):
+        env.prepend_path('PATH', '{0}/molpro_2021.1/bin'.format(self.prefix))

--- a/packages/molpro/package.py
+++ b/packages/molpro/package.py
@@ -17,11 +17,11 @@ class Molpro(CMakePackage):
 
     version('20210528', sha256='c24937ae7119431c1efe972effc712530a3b948b8f2fe7191c9458191b1a4a65')
 
-    depends_on('eigen')
-    depends_on('lapack')
-    depends_on('openblas')
-    depends_on('mpi')
-    depends_on('globalarrays')
     depends_on('python')
     depends_on('icu4c')
+    depends_on('eigen')
+    depends_on('mpi')
+    depends_on('cray-libsci')
+    depends_on('globalarrays')
     depends_on('libxml2')
+

--- a/packages/molpro/package_CMakePackage.py
+++ b/packages/molpro/package_CMakePackage.py
@@ -5,7 +5,7 @@
 from spack import *
 
 
-class Molpro(AutotoolsPackage):
+class Molpro(CMakePackage):
     """Molpro is a comprehensive system of ab initio programs for advanced 
     molecular electronic structure calculations.
     """
@@ -25,10 +25,18 @@ class Molpro(AutotoolsPackage):
     depends_on('globalarrays')
     depends_on('libxml2')
 
-    def configure_args(self):
-        args = []
-
-        args.append('--cache-file=test-cache.txt')
+    def cmake_args(self):
+        args = [
+                '-DBUILD_TESTING:BOOL=ON',
+                #'-DGCI_TEST:BOOL=ON',
+                #'-DSYMMETRY_MATRIX_COMPLEXDOUBLE:BOOL=ON',
+                #'-DSYMMETRY_MATRIX_DOUBLE:BOOL=ON',
+                #'-DSYMMETRY_MATRIX_FLOAT:BOOL=ON',
+                #'-DXCGRID_BUILD_TESTS:BOOL=ON',
+                #'-DWHATEVER:STRING=somevalue',
+                #self.define('ENABLE_BROKEN_FEATURE', False),
+                #self.define_from_variant('DETECT_HDF5', 'hdf5'),
+                #self.define_from_variant('THREADS'), # True if +threads
+                ]
 
         return args
-


### PR DESCRIPTION
- [x] use cray-mpich-ucx and cray-libsci modules
- [x] include directions on tuning and testing molpro prior to installing
